### PR TITLE
VIN decoder now checking and eventually correcting VIN checksum digit

### DIFF
--- a/CommonSuite/Forms/frmDecodeVIN.Designer.cs
+++ b/CommonSuite/Forms/frmDecodeVIN.Designer.cs
@@ -48,6 +48,9 @@ namespace CommonSuite
             this.simpleButton2 = new DevExpress.XtraEditors.SimpleButton();
             this.labelControl2 = new DevExpress.XtraEditors.LabelControl();
             this.lblGearbox = new DevExpress.XtraEditors.LabelControl();
+            this.labelControl3 = new DevExpress.XtraEditors.LabelControl();
+            this.lblChecksum = new DevExpress.XtraEditors.LabelControl();
+            this.btnFixChecksum = new DevExpress.XtraEditors.SimpleButton();
             ((System.ComponentModel.ISupportInitialize)(this.textEdit1.Properties)).BeginInit();
             this.SuspendLayout();
             // 
@@ -222,6 +225,33 @@ namespace CommonSuite
             this.lblGearbox.TabIndex = 18;
             this.lblGearbox.Text = "---";
             // 
+            // labelControl3
+            // 
+            this.labelControl3.Location = new System.Drawing.Point(83, 199);
+            this.labelControl3.Name = "labelControl3";
+            this.labelControl3.Size = new System.Drawing.Size(66, 13);
+            this.labelControl3.TabIndex = 21;
+            this.labelControl3.Text = "VIN checksum";
+            // 
+            // lblChecksum
+            // 
+            this.lblChecksum.Appearance.ForeColor = System.Drawing.Color.DarkBlue;
+            this.lblChecksum.Location = new System.Drawing.Point(196, 199);
+            this.lblChecksum.Name = "lblChecksum";
+            this.lblChecksum.Size = new System.Drawing.Size(12, 13);
+            this.lblChecksum.TabIndex = 20;
+            this.lblChecksum.Text = "---";
+            // 
+            // btnFixChecksum
+            // 
+            this.btnFixChecksum.Enabled = false;
+            this.btnFixChecksum.Location = new System.Drawing.Point(401, 185);
+            this.btnFixChecksum.Name = "btnFixChecksum";
+            this.btnFixChecksum.Size = new System.Drawing.Size(75, 23);
+            this.btnFixChecksum.TabIndex = 22;
+            this.btnFixChecksum.Text = "Fix checksum";
+            this.btnFixChecksum.Click += new System.EventHandler(this.btnFixChecksum_Click);
+            // 
             // frmDecodeVIN
             // 
             this.AcceptButton = this.simpleButton1;
@@ -229,6 +259,9 @@ namespace CommonSuite
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.simpleButton2;
             this.ClientSize = new System.Drawing.Size(488, 249);
+            this.Controls.Add(this.btnFixChecksum);
+            this.Controls.Add(this.labelControl3);
+            this.Controls.Add(this.lblChecksum);
             this.Controls.Add(this.labelControl2);
             this.Controls.Add(this.lblGearbox);
             this.Controls.Add(this.simpleButton2);
@@ -256,7 +289,6 @@ namespace CommonSuite
             this.ShowIcon = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "VIN decoder";
-            
             ((System.ComponentModel.ISupportInitialize)(this.textEdit1.Properties)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -285,5 +317,8 @@ namespace CommonSuite
         private DevExpress.XtraEditors.SimpleButton simpleButton2;
         private DevExpress.XtraEditors.LabelControl labelControl2;
         private DevExpress.XtraEditors.LabelControl lblGearbox;
+        private DevExpress.XtraEditors.LabelControl labelControl3;
+        private DevExpress.XtraEditors.LabelControl lblChecksum;
+        private DevExpress.XtraEditors.SimpleButton btnFixChecksum;
     }
 }

--- a/CommonSuite/Forms/frmDecodeVIN.Designer.cs
+++ b/CommonSuite/Forms/frmDecodeVIN.Designer.cs
@@ -50,7 +50,6 @@ namespace CommonSuite
             this.lblGearbox = new DevExpress.XtraEditors.LabelControl();
             this.labelControl3 = new DevExpress.XtraEditors.LabelControl();
             this.lblChecksum = new DevExpress.XtraEditors.LabelControl();
-            this.btnFixChecksum = new DevExpress.XtraEditors.SimpleButton();
             ((System.ComponentModel.ISupportInitialize)(this.textEdit1.Properties)).BeginInit();
             this.SuspendLayout();
             // 
@@ -242,16 +241,6 @@ namespace CommonSuite
             this.lblChecksum.TabIndex = 20;
             this.lblChecksum.Text = "---";
             // 
-            // btnFixChecksum
-            // 
-            this.btnFixChecksum.Enabled = false;
-            this.btnFixChecksum.Location = new System.Drawing.Point(401, 185);
-            this.btnFixChecksum.Name = "btnFixChecksum";
-            this.btnFixChecksum.Size = new System.Drawing.Size(75, 23);
-            this.btnFixChecksum.TabIndex = 22;
-            this.btnFixChecksum.Text = "Fix checksum";
-            this.btnFixChecksum.Click += new System.EventHandler(this.btnFixChecksum_Click);
-            // 
             // frmDecodeVIN
             // 
             this.AcceptButton = this.simpleButton1;
@@ -259,7 +248,6 @@ namespace CommonSuite
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.simpleButton2;
             this.ClientSize = new System.Drawing.Size(488, 249);
-            this.Controls.Add(this.btnFixChecksum);
             this.Controls.Add(this.labelControl3);
             this.Controls.Add(this.lblChecksum);
             this.Controls.Add(this.labelControl2);
@@ -319,6 +307,5 @@ namespace CommonSuite
         private DevExpress.XtraEditors.LabelControl lblGearbox;
         private DevExpress.XtraEditors.LabelControl labelControl3;
         private DevExpress.XtraEditors.LabelControl lblChecksum;
-        private DevExpress.XtraEditors.SimpleButton btnFixChecksum;
     }
 }

--- a/CommonSuite/Forms/frmDecodeVIN.cs
+++ b/CommonSuite/Forms/frmDecodeVIN.cs
@@ -40,8 +40,10 @@ namespace CommonSuite
             lblSeries.Text = carinfo.Series;
             lblTurbo.Text = carinfo.TurboModel.ToString().Replace("_","-");
             lblGearbox.Text = carinfo.GearboxDescription;
-            char checksum;
-            if (decoder.CalculateChecksum(textEdit1.Text, out checksum)) lblChecksum.Text = checksum == textEdit1.Text[8] ? "Valid" : "WRONG! Expected: " + checksum + " but found: " + textEdit1.Text[8];
+            if (carinfo.CalculatedChecksum != '*')
+            {
+                lblChecksum.Text = carinfo.CalculatedChecksum == textEdit1.Text[8] ? "Valid" : "WRONG! Expected: " + carinfo.CalculatedChecksum + " but found: " + textEdit1.Text[8];
+            }
         }
 
         private void simpleButton1_Click(object sender, EventArgs e)

--- a/CommonSuite/Forms/frmDecodeVIN.cs
+++ b/CommonSuite/Forms/frmDecodeVIN.cs
@@ -21,7 +21,7 @@ namespace CommonSuite
 
         private void DecodeVIN()
         {
-            textEdit1.Text = textEdit1.Text.ToUpper(); // Make sure it is all capitol letters
+            textEdit1.Text = textEdit1.Text.ToUpper();
             lblBody.Text = "---";
             lblCarModel.Text = "---";
             lblEngineType.Text = "---";
@@ -29,6 +29,7 @@ namespace CommonSuite
             lblPlant.Text = "---";
             lblSeries.Text = "---";
             lblTurbo.Text = "---";
+            lblChecksum.Text = "Not verified";
             VINDecoder decoder = new VINDecoder();
             VINCarInfo carinfo = decoder.DecodeVINNumber(textEdit1.Text);
             lblBody.Text = carinfo.Body;
@@ -39,8 +40,8 @@ namespace CommonSuite
             lblSeries.Text = carinfo.Series;
             lblTurbo.Text = carinfo.TurboModel.ToString().Replace("_","-");
             lblGearbox.Text = carinfo.GearboxDescription;
-            lblChecksum.Text = carinfo.IsChecksumValid ? "Valid" : "WRONG!";
-            btnFixChecksum.Enabled = !carinfo.IsChecksumValid;
+            char checksum;
+            if (decoder.CalculateChecksum(textEdit1.Text, out checksum)) lblChecksum.Text = checksum == textEdit1.Text[8] ? "Valid" : "WRONG! Expected: " + checksum + " but found: " + textEdit1.Text[8];
         }
 
         private void simpleButton1_Click(object sender, EventArgs e)
@@ -50,22 +51,8 @@ namespace CommonSuite
 
         public void SetVinNumber(string vinnumber)
         {
-            textEdit1.Text = vinnumber; // Make sure it is all capitol letters
+            textEdit1.Text = vinnumber;
             DecodeVIN();
         }
-
-        private void btnFixChecksum_Click(object sender, EventArgs e)
-        {
-            VINDecoder decoder = new VINDecoder();
-            char checksum;
-            if (decoder.CalculateChecksum(textEdit1.Text, out checksum))
-            {
-                System.Text.StringBuilder strBuilder = new System.Text.StringBuilder(textEdit1.Text);
-                strBuilder[8] = checksum;
-                textEdit1.Text = strBuilder.ToString();
-                DecodeVIN();
-            } 
-        }
-
     }
 }

--- a/CommonSuite/Forms/frmDecodeVIN.cs
+++ b/CommonSuite/Forms/frmDecodeVIN.cs
@@ -21,6 +21,7 @@ namespace CommonSuite
 
         private void DecodeVIN()
         {
+            textEdit1.Text = textEdit1.Text.ToUpper(); // Make sure it is all capitol letters
             lblBody.Text = "---";
             lblCarModel.Text = "---";
             lblEngineType.Text = "---";
@@ -38,18 +39,33 @@ namespace CommonSuite
             lblSeries.Text = carinfo.Series;
             lblTurbo.Text = carinfo.TurboModel.ToString().Replace("_","-");
             lblGearbox.Text = carinfo.GearboxDescription;
+            lblChecksum.Text = carinfo.IsChecksumValid ? "Valid" : "WRONG!";
+            btnFixChecksum.Enabled = !carinfo.IsChecksumValid;
         }
 
         private void simpleButton1_Click(object sender, EventArgs e)
         {
             DecodeVIN();
-            
         }
 
         public void SetVinNumber(string vinnumber)
         {
-            textEdit1.Text = vinnumber;
+            textEdit1.Text = vinnumber; // Make sure it is all capitol letters
             DecodeVIN();
         }
+
+        private void btnFixChecksum_Click(object sender, EventArgs e)
+        {
+            VINDecoder decoder = new VINDecoder();
+            char checksum;
+            if (decoder.CalculateChecksum(textEdit1.Text, out checksum))
+            {
+                System.Text.StringBuilder strBuilder = new System.Text.StringBuilder(textEdit1.Text);
+                strBuilder[8] = checksum;
+                textEdit1.Text = strBuilder.ToString();
+                DecodeVIN();
+            } 
+        }
+
     }
 }

--- a/CommonSuite/VINDecoder.cs
+++ b/CommonSuite/VINDecoder.cs
@@ -168,6 +168,8 @@ namespace CommonSuite
                 _carInfo.Valid = true;
             }
 
+            _carInfo.CalculatedChecksum = CalculateChecksum(VINNumber);
+
             return _carInfo;
         }
 
@@ -562,24 +564,23 @@ V = 2.5 liter V-6
         }
 
         // VIN checksum, for more details: https://en.wikibooks.org/wiki/Vehicle_Identification_Numbers_(VIN_codes)/Check_digit
-        public bool CalculateChecksum(string VINnumber, out char checksum)
+        public char CalculateChecksum(string VINnumber)
         {
-            checksum = '*';
-            if (VINnumber.Length != 17) return false;
+            char checksum = '*'; // * means not possible to calculate checksum
+            if (VINnumber.Length != 17) return checksum;
             int[] weights = new int[17] { 8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2 };
             int sum = 0;
             for (int i = 0; i < 17; i++)
             {
                 if (i == 8) continue; // Skip checksum digit
                 int value = TranslateVINdigit(VINnumber[i]);
-                if (value < 0) return false;
+                if (value < 0) return checksum;
                 sum += value * weights[i];
             }
             int checksumValue = sum % 11;
             if (checksumValue >= 0 && checksumValue <= 9) checksum = checksumValue.ToString()[0];
             else if (checksumValue == 10) checksum = 'X';
-            else return false;
-            return true;
+            return checksum;
         }
 
     }
@@ -654,6 +655,14 @@ V = 2.5 liter V-6
         {
             get { return _gearboxDescription; }
             set { _gearboxDescription = value; }
+        }
+
+        private char _calculatedChecksum = '*';
+
+        public char CalculatedChecksum
+        {
+            get { return _calculatedChecksum; }
+            set { _calculatedChecksum = value; }
         }
     }
 }

--- a/CommonSuite/VINDecoder.cs
+++ b/CommonSuite/VINDecoder.cs
@@ -168,10 +168,6 @@ namespace CommonSuite
                 _carInfo.Valid = true;
             }
 
-            char checksum;
-            if (CalculateChecksum(VINNumber, out checksum)) _carInfo.IsChecksumValid = (checksum == VINNumber[8]);
-            else _carInfo.IsChecksumValid = false;
-
             return _carInfo;
         }
 
@@ -659,22 +655,5 @@ V = 2.5 liter V-6
             get { return _gearboxDescription; }
             set { _gearboxDescription = value; }
         }
-
-        private string _checksumText;
-
-        public string ChecksumText
-        {
-            get { return _checksumText; }
-            set { _checksumText = value; }
-        }
-
-        private bool _validChecksum;
-
-        public bool IsChecksumValid
-        {
-            get { return _validChecksum; }
-            set { _validChecksum = value; }
-        }
-
     }
 }

--- a/SuiteTest/VINDecoderTest.cs
+++ b/SuiteTest/VINDecoderTest.cs
@@ -82,6 +82,7 @@ namespace T8Test
             Assert.AreEqual("5 speed manual / front wheel drive", actual.GearboxDescription);
             Assert.AreEqual("Trollhättan line A (9-5)", actual.PlantInfo);
             Assert.AreEqual("Model series I, Driver and passenger airbags", actual.Series);
+            Assert.AreEqual(actual.CalculatedChecksum, VINNumber[8]);
             // Serialnumber not decoded 012475
         }
 
@@ -103,6 +104,7 @@ namespace T8Test
             Assert.AreEqual("5 speed manual / front wheel drive", actual.GearboxDescription);
             Assert.AreEqual("Trollhättan line A (9-5)", actual.PlantInfo);
             Assert.AreEqual("Model series IV, Driver and passenger airbags", actual.Series);
+            Assert.AreEqual(actual.CalculatedChecksum, VINNumber[8]);
             // Serialnumber not decoded 510826
         }
         
@@ -124,6 +126,7 @@ namespace T8Test
             Assert.AreEqual("6 speed automatic / all wheel drive", actual.GearboxDescription);
             Assert.AreEqual("Trollhättan line A (9-3)", actual.PlantInfo);
             Assert.AreEqual("Saab 9-3 TurboX", actual.Series);
+            Assert.AreEqual(actual.CalculatedChecksum, VINNumber[8]);
             // Serialnumber not decoded 130440
         }
 
@@ -145,6 +148,7 @@ namespace T8Test
             Assert.AreEqual("5 speed automatic / front wheel drive", actual.GearboxDescription);
             Assert.AreEqual("Trollhättan line A (9-5)", actual.PlantInfo);
             Assert.AreEqual("Model series I, Driver and passenger airbags", actual.Series);
+            Assert.AreEqual(actual.CalculatedChecksum, VINNumber[8]);
             // Serialnumber not decoded 505541
         }
         
@@ -166,6 +170,7 @@ namespace T8Test
             Assert.AreEqual("6 speed automatic / all wheel drive", actual.GearboxDescription);
             Assert.AreEqual("Trollhättan (9-5)", actual.PlantInfo);
             Assert.AreEqual("Saab 9-5 Aero", actual.Series);
+            Assert.AreEqual(actual.CalculatedChecksum, VINNumber[8]);
             // Serialnumber not decoded 001333
         }
 
@@ -187,6 +192,7 @@ namespace T8Test
             Assert.AreEqual("6 speed manual / all wheel drive", actual.GearboxDescription);
             Assert.AreEqual("Trollhättan line A (9-3)", actual.PlantInfo);
             Assert.AreEqual("Saab 9-3 X", actual.Series);
+            Assert.AreEqual(actual.CalculatedChecksum, VINNumber[8]);
             // Serialnumber not decoded 306559
         }
 
@@ -208,6 +214,7 @@ namespace T8Test
             Assert.AreEqual("6 speed automatic / front wheel drive", actual.GearboxDescription);
             Assert.AreEqual("Trollhättan (9-5)", actual.PlantInfo);
             Assert.AreEqual("Saab 9-5 Vector", actual.Series);
+            Assert.AreEqual(actual.CalculatedChecksum, VINNumber[8]);
             // Serialnumber not decoded 002240
         }
 
@@ -229,6 +236,7 @@ namespace T8Test
             Assert.AreEqual("6 speed automatic / front wheel drive", actual.GearboxDescription);
             Assert.AreEqual("Trollhättan line B (900 / 9-3)", actual.PlantInfo);
             Assert.AreEqual("Model series I, Driver and passenger airbags", actual.Series);
+            Assert.AreEqual(actual.CalculatedChecksum, VINNumber[8]);
             // Serialnumber not decoded 301688
         }
 
@@ -250,6 +258,7 @@ namespace T8Test
             Assert.AreEqual("6 speed manual / front wheel drive", actual.GearboxDescription);
             Assert.AreEqual("Trollhättan line B (900 / 9-3)", actual.PlantInfo);
             Assert.AreEqual("Model series II, Driver and passenger airbags", actual.Series);
+            Assert.AreEqual(actual.CalculatedChecksum, VINNumber[8]);
             // Serialnumber not decoded 300776
         }
 
@@ -267,7 +276,140 @@ namespace T8Test
             Assert.AreEqual(2005, actual.Makeyear);
             Assert.AreEqual(VINEngineType.Z20NET, actual.EngineType);
             Assert.AreEqual(VINTurboModel.GarrettGT2052, actual.TurboModel);
+            Assert.AreNotEqual(actual.CalculatedChecksum, VINNumber[8]);
             // Serialnumber not decoded 095720
+        }
+
+        /// <summary>
+        ///A test for DecodeVINNumber
+        ///</summary>
+        [TestMethod()]
+        public void DecodeVINNumberTestYS3EE55EX63507433()
+        {
+            VINDecoder target = new VINDecoder();
+            string VINNumber = "YS3EE55EX63507433";
+            VINCarInfo actual;
+            actual = target.DecodeVINNumber(VINNumber);
+            Assert.AreEqual(VINCarModel.Saab95, actual.CarModel);
+            Assert.AreEqual(2006, actual.Makeyear);
+            Assert.AreEqual("5 door combi coupe", actual.Body);
+            Assert.AreEqual(VINEngineType.B235E, actual.EngineType);
+            Assert.AreEqual(VINTurboModel.GarrettGT1752, actual.TurboModel);
+            Assert.AreEqual("5 speed manual / front wheel drive", actual.GearboxDescription);
+            Assert.AreEqual("Trollhättan line A (9-5)", actual.PlantInfo);
+            Assert.AreEqual("Model series III, Driver airbag", actual.Series);
+            Assert.AreEqual(actual.CalculatedChecksum, VINNumber[8]);
+            // Serialnumber not decoded 002240
+        }
+
+        /// <summary>
+        ///A test for DecodeVINNumber
+        ///</summary>
+        [TestMethod()]
+        public void DecodeVINNumberTestYS3EE55EX63507423()
+        {
+            VINDecoder target = new VINDecoder();
+            string VINNumber = "YS3EE55EX63507423";
+            VINCarInfo actual;
+            actual = target.DecodeVINNumber(VINNumber);
+            Assert.AreEqual(VINCarModel.Saab95, actual.CarModel);
+            Assert.AreEqual(2006, actual.Makeyear);
+            Assert.AreEqual("5 door combi coupe", actual.Body);
+            Assert.AreEqual(VINEngineType.B235E, actual.EngineType);
+            Assert.AreEqual(VINTurboModel.GarrettGT1752, actual.TurboModel);
+            Assert.AreEqual("5 speed manual / front wheel drive", actual.GearboxDescription);
+            Assert.AreEqual("Trollhättan line A (9-5)", actual.PlantInfo);
+            Assert.AreEqual("Model series III, Driver airbag", actual.Series);
+            Assert.AreNotEqual(actual.CalculatedChecksum, VINNumber[8]);
+            // Serialnumber not decoded
+        }
+
+        /// <summary>
+        ///A test for DecodeVINNumber
+        ///</summary>
+        [TestMethod()]
+        public void DecodeVINNumberTestYS3EE55E263507433()
+        {
+            VINDecoder target = new VINDecoder();
+            string VINNumber = "YS3EE55E263507433";
+            VINCarInfo actual;
+            actual = target.DecodeVINNumber(VINNumber);
+            Assert.AreEqual(VINCarModel.Saab95, actual.CarModel);
+            Assert.AreEqual(2006, actual.Makeyear);
+            Assert.AreEqual("5 door combi coupe", actual.Body);
+            Assert.AreEqual(VINEngineType.B235E, actual.EngineType);
+            Assert.AreEqual(VINTurboModel.GarrettGT1752, actual.TurboModel);
+            Assert.AreEqual("5 speed manual / front wheel drive", actual.GearboxDescription);
+            Assert.AreEqual("Trollhättan line A (9-5)", actual.PlantInfo);
+            Assert.AreEqual("Model series III, Driver airbag", actual.Series);
+            Assert.AreNotEqual(actual.CalculatedChecksum, VINNumber[8]);
+            // Serialnumber not decoded
+        }
+
+        /// <summary>
+        ///A test for DecodeVINNumber
+        ///</summary>
+        [TestMethod()]
+        public void DecodeVINNumberTestYS3EE55GX63507433()
+        {
+            VINDecoder target = new VINDecoder();
+            string VINNumber = "YS3EE55GX63507433";
+            VINCarInfo actual;
+            actual = target.DecodeVINNumber(VINNumber);
+            Assert.AreEqual(VINCarModel.Saab95, actual.CarModel);
+            Assert.AreEqual(2006, actual.Makeyear);
+            Assert.AreEqual("5 door combi coupe", actual.Body);
+            Assert.AreEqual(VINEngineType.B235R, actual.EngineType);
+            Assert.AreEqual(VINTurboModel.MitsubishiTD04HL_15T_5, actual.TurboModel);
+            Assert.AreEqual("5 speed manual / front wheel drive", actual.GearboxDescription);
+            Assert.AreEqual("Trollhättan line A (9-5)", actual.PlantInfo);
+            Assert.AreEqual("Model series III, Driver airbag", actual.Series);
+            Assert.AreNotEqual(actual.CalculatedChecksum, VINNumber[8]);
+            // Serialnumber not decoded
+        }
+
+        /// <summary>
+        ///A test for DecodeVINNumber
+        ///</summary>
+        [TestMethod()]
+        public void DecodeVINNumberTestYS3EE55G863507433()
+        {
+            VINDecoder target = new VINDecoder();
+            string VINNumber = "YS3EE55G863507433";
+            VINCarInfo actual;
+            actual = target.DecodeVINNumber(VINNumber);
+            Assert.AreEqual(VINCarModel.Saab95, actual.CarModel);
+            Assert.AreEqual(2006, actual.Makeyear);
+            Assert.AreEqual("5 door combi coupe", actual.Body);
+            Assert.AreEqual(VINEngineType.B235R, actual.EngineType);
+            Assert.AreEqual(VINTurboModel.MitsubishiTD04HL_15T_5, actual.TurboModel);
+            Assert.AreEqual("5 speed manual / front wheel drive", actual.GearboxDescription);
+            Assert.AreEqual("Trollhättan line A (9-5)", actual.PlantInfo);
+            Assert.AreEqual("Model series III, Driver airbag", actual.Series);
+            Assert.AreEqual(actual.CalculatedChecksum, VINNumber[8]);
+            // Serialnumber not decoded
+        }
+
+        /// <summary>
+        ///A test for DecodeVINNumber
+        ///</summary>
+        [TestMethod()]
+        public void DecodeVINNumberTestYS3EE55G863507633()
+        {
+            VINDecoder target = new VINDecoder();
+            string VINNumber = "YS3EE55G863507633";
+            VINCarInfo actual;
+            actual = target.DecodeVINNumber(VINNumber);
+            Assert.AreEqual(VINCarModel.Saab95, actual.CarModel);
+            Assert.AreEqual(2006, actual.Makeyear);
+            Assert.AreEqual("5 door combi coupe", actual.Body);
+            Assert.AreEqual(VINEngineType.B235R, actual.EngineType);
+            Assert.AreEqual(VINTurboModel.MitsubishiTD04HL_15T_5, actual.TurboModel);
+            Assert.AreEqual("5 speed manual / front wheel drive", actual.GearboxDescription);
+            Assert.AreEqual("Trollhättan line A (9-5)", actual.PlantInfo);
+            Assert.AreEqual("Model series III, Driver airbag", actual.Series);
+            Assert.AreNotEqual(actual.CalculatedChecksum, VINNumber[8]);
+            // Serialnumber not decoded
         }
     }
 }


### PR DESCRIPTION
In the VIN decoder I added the information about the VIN checksum.
VIN checksum is the 9th character in the VIN.
The way how it is calculated is described [here](https://en.wikibooks.org/wiki/Vehicle_Identification_Numbers_(VIN_codes)/Check_digit).
The VIN decoder is now telling if the inserted VIN has a valid checksum or not.
If the checksum is wrong the button "Fix checksum" will allow the user to automatically replace the checksum character with the right one.
