### PR TITLE
Background color of MapViewer fixed and other build fixes.

### DIFF
--- a/SetupT7Suite/SetupT7Suite.vdproj
+++ b/SetupT7Suite/SetupT7Suite.vdproj
@@ -448,13 +448,13 @@
         "Entry"
         {
         "MsmKey" = "8:_54F3152B932B273A13ABB21A06FEE667"
-        "OwnerKey" = "8:_0D10EC955A79B045AC50424EA5762DE2"
+        "OwnerKey" = "8:_6F820B8014DE4A9F9FA66725E3B6203E"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
         "MsmKey" = "8:_54F3152B932B273A13ABB21A06FEE667"
-        "OwnerKey" = "8:_6F820B8014DE4A9F9FA66725E3B6203E"
+        "OwnerKey" = "8:_0D10EC955A79B045AC50424EA5762DE2"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -957,12 +957,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_B0D318A130036514BF744607AD683589"
-        "OwnerKey" = "8:_6F820B8014DE4A9F9FA66725E3B6203E"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_B173C26D9A95375F278FE7EF58E7B3A0"
         "OwnerKey" = "8:_6F820B8014DE4A9F9FA66725E3B6203E"
         "MsmSig" = "8:_UNDEFINED"
@@ -1095,18 +1089,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_D3920D7742498C560D125574D231AC1D"
-        "OwnerKey" = "8:_4E92752204E40FDF0253A723EFF76DFA"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_D3920D7742498C560D125574D231AC1D"
-        "OwnerKey" = "8:_6F820B8014DE4A9F9FA66725E3B6203E"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_D45297992A3ECBA1F1B24C2C78565781"
         "OwnerKey" = "8:_54CD83717521ADDDDA6FAF7588418BDE"
         "MsmSig" = "8:_UNDEFINED"
@@ -1222,13 +1204,13 @@
         "Entry"
         {
         "MsmKey" = "8:_EF990578BE547F68156B7B2A8E987447"
-        "OwnerKey" = "8:_FB2A91CCBF8652A06FB516603051C58B"
+        "OwnerKey" = "8:_54F3152B932B273A13ABB21A06FEE667"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
         "MsmKey" = "8:_EF990578BE547F68156B7B2A8E987447"
-        "OwnerKey" = "8:_54F3152B932B273A13ABB21A06FEE667"
+        "OwnerKey" = "8:_FB2A91CCBF8652A06FB516603051C58B"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1359,6 +1341,18 @@
         }
         "Entry"
         {
+        "MsmKey" = "8:_F48D9711B4B97D8A49B3F0567A36292B"
+        "OwnerKey" = "8:_4E92752204E40FDF0253A723EFF76DFA"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_F48D9711B4B97D8A49B3F0567A36292B"
+        "OwnerKey" = "8:_6F820B8014DE4A9F9FA66725E3B6203E"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
         "MsmKey" = "8:_F55C95B0526A748E87B61AAC8F777854"
         "OwnerKey" = "8:_6F820B8014DE4A9F9FA66725E3B6203E"
         "MsmSig" = "8:_UNDEFINED"
@@ -1395,6 +1389,12 @@
         }
         "Entry"
         {
+        "MsmKey" = "8:_F824B5871FCF50BAEC203E737A279C4F"
+        "OwnerKey" = "8:_6F820B8014DE4A9F9FA66725E3B6203E"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
         "MsmKey" = "8:_FB2A91CCBF8652A06FB516603051C58B"
         "OwnerKey" = "8:_6F820B8014DE4A9F9FA66725E3B6203E"
         "MsmSig" = "8:_UNDEFINED"
@@ -1409,6 +1409,48 @@
         {
         "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_6F820B8014DE4A9F9FA66725E3B6203E"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_E3110D27C26DAA26458164FE325EB116"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_C77FE8945C66DC4AA0986A985E42FE89"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_F824B5871FCF50BAEC203E737A279C4F"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_E8F64210CED2215B1CDADAC21494D95E"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_4E92752204E40FDF0253A723EFF76DFA"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_AF123C2D9751D29E8DDF3280D0AC175A"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_8A75931D9F0A684557F710024A8CD384"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1444,7 +1486,7 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_E3110D27C26DAA26458164FE325EB116"
+        "OwnerKey" = "8:_54F3152B932B273A13ABB21A06FEE667"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1456,37 +1498,13 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_C77FE8945C66DC4AA0986A985E42FE89"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_B0D318A130036514BF744607AD683589"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_B173C26D9A95375F278FE7EF58E7B3A0"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_E8F64210CED2215B1CDADAC21494D95E"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_91711C37FC70951BC78ADB04CF144D0A"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_4E92752204E40FDF0253A723EFF76DFA"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1546,19 +1564,7 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_D3920D7742498C560D125574D231AC1D"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_AF123C2D9751D29E8DDF3280D0AC175A"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_8A75931D9F0A684557F710024A8CD384"
+        "OwnerKey" = "8:_F48D9711B4B97D8A49B3F0567A36292B"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1571,12 +1577,6 @@
         {
         "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_0D10EC955A79B045AC50424EA5762DE2"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_54F3152B932B273A13ABB21A06FEE667"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -3119,37 +3119,6 @@
             "IsDependency" = "11:TRUE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_B0D318A130036514BF744607AD683589"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:PSTaskDialog, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_B0D318A130036514BF744607AD683589"
-                    {
-                    "Name" = "8:PSTaskDialog.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:PSTaskDialog.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_1724C4C0C3D34AE68BA9B523B82731D8"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:TRUE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_B173C26D9A95375F278FE7EF58E7B3A0"
             {
             "AssemblyRegister" = "3:1"
@@ -3522,37 +3491,6 @@
             "IsDependency" = "11:TRUE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_D3920D7742498C560D125574D231AC1D"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:ICSharpCode.TextEditor, Version=3.0.0.3437, Culture=neutral, PublicKeyToken=4d61825e8dd49f1a, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_D3920D7742498C560D125574D231AC1D"
-                    {
-                    "Name" = "8:ICSharpCode.TextEditor.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:ICSharpCode.TextEditor.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_1724C4C0C3D34AE68BA9B523B82731D8"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:TRUE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_D45297992A3ECBA1F1B24C2C78565781"
             {
             "AssemblyRegister" = "3:1"
@@ -3774,7 +3712,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:ProCharts, Version=1.0.6426.24455, Culture=neutral, processorArchitecture=x86"
+            "AssemblyAsmDisplayName" = "8:ProCharts, Version=1.0.6428.27401, Culture=neutral, processorArchitecture=x86"
                 "ScatterAssemblies"
                 {
                     "_E8F64210CED2215B1CDADAC21494D95E"
@@ -3863,6 +3801,37 @@
             "IsDependency" = "11:TRUE"
             "IsolateTo" = "8:"
             }
+            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_F48D9711B4B97D8A49B3F0567A36292B"
+            {
+            "AssemblyRegister" = "3:1"
+            "AssemblyIsInGAC" = "11:FALSE"
+            "AssemblyAsmDisplayName" = "8:ICSharpCode.TextEditor, Version=3.0.0.3437, Culture=neutral, PublicKeyToken=4d61825e8dd49f1a, processorArchitecture=x86"
+                "ScatterAssemblies"
+                {
+                    "_F48D9711B4B97D8A49B3F0567A36292B"
+                    {
+                    "Name" = "8:ICSharpCode.TextEditor.dll"
+                    "Attributes" = "3:512"
+                    }
+                }
+            "SourcePath" = "8:ICSharpCode.TextEditor.dll"
+            "TargetName" = "8:"
+            "Tag" = "8:"
+            "Folder" = "8:_1724C4C0C3D34AE68BA9B523B82731D8"
+            "Condition" = "8:"
+            "Transitive" = "11:FALSE"
+            "Vital" = "11:TRUE"
+            "ReadOnly" = "11:FALSE"
+            "Hidden" = "11:FALSE"
+            "System" = "11:FALSE"
+            "Permanent" = "11:FALSE"
+            "SharedLegacy" = "11:FALSE"
+            "PackageAs" = "3:1"
+            "Register" = "3:1"
+            "Exclude" = "11:FALSE"
+            "IsDependency" = "11:TRUE"
+            "IsolateTo" = "8:"
+            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_F55C95B0526A748E87B61AAC8F777854"
             {
             "AssemblyRegister" = "3:1"
@@ -3908,6 +3877,37 @@
                     }
                 }
             "SourcePath" = "8:Microsoft.Vbe.Interop.dll"
+            "TargetName" = "8:"
+            "Tag" = "8:"
+            "Folder" = "8:_1724C4C0C3D34AE68BA9B523B82731D8"
+            "Condition" = "8:"
+            "Transitive" = "11:FALSE"
+            "Vital" = "11:TRUE"
+            "ReadOnly" = "11:FALSE"
+            "Hidden" = "11:FALSE"
+            "System" = "11:FALSE"
+            "Permanent" = "11:FALSE"
+            "SharedLegacy" = "11:FALSE"
+            "PackageAs" = "3:1"
+            "Register" = "3:1"
+            "Exclude" = "11:FALSE"
+            "IsDependency" = "11:TRUE"
+            "IsolateTo" = "8:"
+            }
+            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_F824B5871FCF50BAEC203E737A279C4F"
+            {
+            "AssemblyRegister" = "3:1"
+            "AssemblyIsInGAC" = "11:FALSE"
+            "AssemblyAsmDisplayName" = "8:PSTaskDialog, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86"
+                "ScatterAssemblies"
+                {
+                    "_F824B5871FCF50BAEC203E737A279C4F"
+                    {
+                    "Name" = "8:PSTaskDialog.dll"
+                    "Attributes" = "3:512"
+                    }
+                }
+            "SourcePath" = "8:PSTaskDialog.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_1724C4C0C3D34AE68BA9B523B82731D8"
@@ -4044,7 +4044,7 @@
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:T7Suite"
         "ProductCode" = "8:{5295558C-BF3B-4CC8-A9AB-27E0A0953A86}"
-        "PackageCode" = "8:{7A9A061B-5AA6-471D-87EA-3AE61F65F8EC}"
+        "PackageCode" = "8:{B47A3559-B3B9-4874-968A-5D06000B6AE5}"
         "UpgradeCode" = "8:{9C2F3019-BC14-4E3F-A0CC-87BFB3182E7D}"
         "AspNetVersion" = "8:4.0.30319.0"
         "RestartWWWService" = "11:FALSE"
@@ -4677,7 +4677,7 @@
             }
             "{5259A561-127C-4D43-A0A1-72F10C7B3BF8}:_6F820B8014DE4A9F9FA66725E3B6203E"
             {
-            "SourcePath" = "8:..\\T7Suite\\obj\\x86\\Release\\T7.exe"
+            "SourcePath" = "8:..\\T7Suite\\obj\\x86\\Debug\\T7.exe"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_1724C4C0C3D34AE68BA9B523B82731D8"

--- a/SetupT8SuitePro/SetupT8SuitePro.vdproj
+++ b/SetupT8SuitePro/SetupT8SuitePro.vdproj
@@ -135,12 +135,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_2136B843E2FE0F3B0FF5A7AFB49F77C1"
-        "OwnerKey" = "8:_2501F8CD56F14E15861AA14CF71FB1C9"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_2501F8CD56F14E15861AA14CF71FB1C9"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -357,6 +351,12 @@
         }
         "Entry"
         {
+        "MsmKey" = "8:_42228CE43B46F4B03754255C6F99D98F"
+        "OwnerKey" = "8:_2501F8CD56F14E15861AA14CF71FB1C9"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
         "MsmKey" = "8:_4803C795DF65C135E15232772FFCF3C7"
         "OwnerKey" = "8:_17364AE5318C4249A6081865B292B194"
         "MsmSig" = "8:_UNDEFINED"
@@ -435,6 +435,18 @@
         }
         "Entry"
         {
+        "MsmKey" = "8:_5EDB85E0907724B58CA0A5EA4E8D54B5"
+        "OwnerKey" = "8:_67E9D95AD8DA192F6A52313B21F483F9"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_5EDB85E0907724B58CA0A5EA4E8D54B5"
+        "OwnerKey" = "8:_2501F8CD56F14E15861AA14CF71FB1C9"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
         "MsmKey" = "8:_62B984655F3F69ABCEF56B0C4226BEBF"
         "OwnerKey" = "8:_314070464A1E68089BF052856D209972"
         "MsmSig" = "8:_UNDEFINED"
@@ -484,6 +496,12 @@
         "Entry"
         {
         "MsmKey" = "8:_7198497CF50775F939722933A636BB0F"
+        "OwnerKey" = "8:_31F3519BD887F1450D2E92DA7A6EB848"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_7198497CF50775F939722933A636BB0F"
         "OwnerKey" = "8:_67E9D95AD8DA192F6A52313B21F483F9"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -491,12 +509,6 @@
         {
         "MsmKey" = "8:_7198497CF50775F939722933A636BB0F"
         "OwnerKey" = "8:_2501F8CD56F14E15861AA14CF71FB1C9"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_7198497CF50775F939722933A636BB0F"
-        "OwnerKey" = "8:_31F3519BD887F1450D2E92DA7A6EB848"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1125,18 +1137,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_A1E1AE70F1B66BA8052A71E079F7295E"
-        "OwnerKey" = "8:_67E9D95AD8DA192F6A52313B21F483F9"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_A1E1AE70F1B66BA8052A71E079F7295E"
-        "OwnerKey" = "8:_2501F8CD56F14E15861AA14CF71FB1C9"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_B216733461FE4317837DFF35C03E263E"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -1366,6 +1366,36 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_316E2DF10474BCBDEDAB718C5EE80384"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_921B4CA84C00BA39FA001BBCF640A33B"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_42228CE43B46F4B03754255C6F99D98F"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_31F3519BD887F1450D2E92DA7A6EB848"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_67E9D95AD8DA192F6A52313B21F483F9"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_F03B0660010D928D60A137797F0D3B18"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -1438,36 +1468,6 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_316E2DF10474BCBDEDAB718C5EE80384"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_921B4CA84C00BA39FA001BBCF640A33B"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_2136B843E2FE0F3B0FF5A7AFB49F77C1"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_31F3519BD887F1450D2E92DA7A6EB848"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_67E9D95AD8DA192F6A52313B21F483F9"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_314070464A1E68089BF052856D209972"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -1528,7 +1528,7 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_A1E1AE70F1B66BA8052A71E079F7295E"
+        "OwnerKey" = "8:_5EDB85E0907724B58CA0A5EA4E8D54B5"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1994,37 +1994,6 @@
             "IsDependency" = "11:TRUE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_2136B843E2FE0F3B0FF5A7AFB49F77C1"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:PSTaskDialog, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_2136B843E2FE0F3B0FF5A7AFB49F77C1"
-                    {
-                    "Name" = "8:PSTaskDialog.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:PSTaskDialog.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_7137F44697BC42C2ABF987D8A5C6E914"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:TRUE"
-            "IsolateTo" = "8:"
-            }
             "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_272D6A7ED8CB4BC2A309142D0692B13F"
             {
             "SourcePath" = "8:..\\TuningPacks\\FD_Torque_Limiter_Removal.t8x"
@@ -2384,6 +2353,37 @@
             "IsDependency" = "11:TRUE"
             "IsolateTo" = "8:"
             }
+            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_42228CE43B46F4B03754255C6F99D98F"
+            {
+            "AssemblyRegister" = "3:1"
+            "AssemblyIsInGAC" = "11:FALSE"
+            "AssemblyAsmDisplayName" = "8:PSTaskDialog, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86"
+                "ScatterAssemblies"
+                {
+                    "_42228CE43B46F4B03754255C6F99D98F"
+                    {
+                    "Name" = "8:PSTaskDialog.dll"
+                    "Attributes" = "3:512"
+                    }
+                }
+            "SourcePath" = "8:PSTaskDialog.dll"
+            "TargetName" = "8:"
+            "Tag" = "8:"
+            "Folder" = "8:_7137F44697BC42C2ABF987D8A5C6E914"
+            "Condition" = "8:"
+            "Transitive" = "11:FALSE"
+            "Vital" = "11:TRUE"
+            "ReadOnly" = "11:FALSE"
+            "Hidden" = "11:FALSE"
+            "System" = "11:FALSE"
+            "Permanent" = "11:FALSE"
+            "SharedLegacy" = "11:FALSE"
+            "PackageAs" = "3:1"
+            "Register" = "3:1"
+            "Exclude" = "11:FALSE"
+            "IsDependency" = "11:TRUE"
+            "IsolateTo" = "8:"
+            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_4803C795DF65C135E15232772FFCF3C7"
             {
             "AssemblyRegister" = "3:1"
@@ -2557,6 +2557,37 @@
             "Register" = "3:1"
             "Exclude" = "11:FALSE"
             "IsDependency" = "11:FALSE"
+            "IsolateTo" = "8:"
+            }
+            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_5EDB85E0907724B58CA0A5EA4E8D54B5"
+            {
+            "AssemblyRegister" = "3:1"
+            "AssemblyIsInGAC" = "11:FALSE"
+            "AssemblyAsmDisplayName" = "8:ICSharpCode.TextEditor, Version=3.0.0.3437, Culture=neutral, PublicKeyToken=4d61825e8dd49f1a, processorArchitecture=x86"
+                "ScatterAssemblies"
+                {
+                    "_5EDB85E0907724B58CA0A5EA4E8D54B5"
+                    {
+                    "Name" = "8:ICSharpCode.TextEditor.dll"
+                    "Attributes" = "3:512"
+                    }
+                }
+            "SourcePath" = "8:ICSharpCode.TextEditor.dll"
+            "TargetName" = "8:"
+            "Tag" = "8:"
+            "Folder" = "8:_7137F44697BC42C2ABF987D8A5C6E914"
+            "Condition" = "8:"
+            "Transitive" = "11:FALSE"
+            "Vital" = "11:TRUE"
+            "ReadOnly" = "11:FALSE"
+            "Hidden" = "11:FALSE"
+            "System" = "11:FALSE"
+            "Permanent" = "11:FALSE"
+            "SharedLegacy" = "11:FALSE"
+            "PackageAs" = "3:1"
+            "Register" = "3:1"
+            "Exclude" = "11:FALSE"
+            "IsDependency" = "11:TRUE"
             "IsolateTo" = "8:"
             }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_62B984655F3F69ABCEF56B0C4226BEBF"
@@ -3434,37 +3465,6 @@
             "IsDependency" = "11:TRUE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_A1E1AE70F1B66BA8052A71E079F7295E"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:ICSharpCode.TextEditor, Version=3.0.0.3437, Culture=neutral, PublicKeyToken=4d61825e8dd49f1a, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_A1E1AE70F1B66BA8052A71E079F7295E"
-                    {
-                    "Name" = "8:ICSharpCode.TextEditor.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:ICSharpCode.TextEditor.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_7137F44697BC42C2ABF987D8A5C6E914"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:TRUE"
-            "IsolateTo" = "8:"
-            }
             "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_B216733461FE4317837DFF35C03E263E"
             {
             "SourcePath" = "8:..\\TuningPacks\\B207E_L_Suite_St1_MY03-06.t8x"
@@ -3996,7 +3996,7 @@
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:T8SuitePro"
         "ProductCode" = "8:{2A900463-8C99-49E8-A8F8-415D291C3997}"
-        "PackageCode" = "8:{FB5CD140-5DDF-4B12-B2B0-40C6708B95CF}"
+        "PackageCode" = "8:{10690A13-171F-4DEA-9DF9-C19C52F236BF}"
         "UpgradeCode" = "8:{D1B8E08D-7E0E-4F1D-89D4-7AA63766CCF6}"
         "AspNetVersion" = "8:4.0.30319.0"
         "RestartWWWService" = "11:FALSE"

--- a/T7.sln
+++ b/T7.sln
@@ -29,14 +29,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommonSuite", "CommonSuite\
 EndProject
 Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "SetupT7Extras", "SetupT7Extras\SetupT7Extras.vdproj", "{9FE31BA1-2761-43E4-A024-F7C9CAEE4CA2}"
 EndProject
-Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "SetupT7Suite", "SetupT7Suite\SetupT7Suite.vdproj", "{2797CCD3-055C-4B29-81FB-F72ACF12C40A}"
-	ProjectSection(ProjectDependencies) = postProject
-		{6DCFB06D-4B31-4D4E-BF49-41F5285B396B} = {6DCFB06D-4B31-4D4E-BF49-41F5285B396B}
-	EndProjectSection
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SuiteLauncher", "SuiteLauncher\SuiteLauncher.csproj", "{6DCFB06D-4B31-4D4E-BF49-41F5285B396B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "T7SuiteTest", "SuiteTest\T7SuiteTest.csproj", "{EF70B008-BDF2-4E77-BF9F-DE97C7377FF8}"
+EndProject
+Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "SetupT7Suite", "SetupT7Suite\SetupT7Suite.vdproj", "{C05EDAE0-C65E-4321-B9DA-E7FEF27888C0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -120,12 +117,6 @@ Global
 		{9FE31BA1-2761-43E4-A024-F7C9CAEE4CA2}.Release|Any CPU.ActiveCfg = Release
 		{9FE31BA1-2761-43E4-A024-F7C9CAEE4CA2}.Release|Any CPU.Build.0 = Release
 		{9FE31BA1-2761-43E4-A024-F7C9CAEE4CA2}.Release|x86.ActiveCfg = Release
-		{2797CCD3-055C-4B29-81FB-F72ACF12C40A}.Debug|Any CPU.ActiveCfg = Release
-		{2797CCD3-055C-4B29-81FB-F72ACF12C40A}.Debug|Any CPU.Build.0 = Release
-		{2797CCD3-055C-4B29-81FB-F72ACF12C40A}.Debug|x86.ActiveCfg = Release
-		{2797CCD3-055C-4B29-81FB-F72ACF12C40A}.Release|Any CPU.ActiveCfg = Release
-		{2797CCD3-055C-4B29-81FB-F72ACF12C40A}.Release|Any CPU.Build.0 = Release
-		{2797CCD3-055C-4B29-81FB-F72ACF12C40A}.Release|x86.ActiveCfg = Release
 		{6DCFB06D-4B31-4D4E-BF49-41F5285B396B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6DCFB06D-4B31-4D4E-BF49-41F5285B396B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6DCFB06D-4B31-4D4E-BF49-41F5285B396B}.Debug|x86.ActiveCfg = Debug|x86
@@ -142,6 +133,12 @@ Global
 		{EF70B008-BDF2-4E77-BF9F-DE97C7377FF8}.Release|Any CPU.Build.0 = Release|Any CPU
 		{EF70B008-BDF2-4E77-BF9F-DE97C7377FF8}.Release|x86.ActiveCfg = Release|x86
 		{EF70B008-BDF2-4E77-BF9F-DE97C7377FF8}.Release|x86.Build.0 = Release|x86
+		{C05EDAE0-C65E-4321-B9DA-E7FEF27888C0}.Debug|Any CPU.ActiveCfg = Release
+		{C05EDAE0-C65E-4321-B9DA-E7FEF27888C0}.Debug|Any CPU.Build.0 = Release
+		{C05EDAE0-C65E-4321-B9DA-E7FEF27888C0}.Debug|x86.ActiveCfg = Release
+		{C05EDAE0-C65E-4321-B9DA-E7FEF27888C0}.Release|Any CPU.ActiveCfg = Release
+		{C05EDAE0-C65E-4321-B9DA-E7FEF27888C0}.Release|Any CPU.Build.0 = Release
+		{C05EDAE0-C65E-4321-B9DA-E7FEF27888C0}.Release|x86.ActiveCfg = Release
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/T7Suite/Plot3D/ColorSchema.cs
+++ b/T7Suite/Plot3D/ColorSchema.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Drawing;
-using System.Text;
 
 namespace Plot3D
 {

--- a/T7Suite/Plot3D/Surface3DRenderer.cs
+++ b/T7Suite/Plot3D/Surface3DRenderer.cs
@@ -1,12 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Drawing.Drawing2D;
-using System.Text;
-using System.Windows.Forms;
-using System.Runtime.CompilerServices;
-using System.Diagnostics;
-using CommonSuite;
 using NLog;
 
 namespace Plot3D

--- a/T7Suite/SurfaceGraphViewer.cs
+++ b/T7Suite/SurfaceGraphViewer.cs
@@ -687,8 +687,8 @@ namespace T7
         {
             int delta = e.Delta;
             //if((uint)e.Delta > 0xff000000) delta = (int)(0x100000000- (long)delta);
-            logger.Debug("e.Delta: " + e.Delta.ToString());
-            logger.Debug("Delta: " + delta.ToString());
+            logger.Debug("e.Delta: " + e.Delta);
+            logger.Debug("Delta: " + delta);
             pov_d += (delta * 0.0001);
             sr.ReCalculateTransformationsCoeficients(pov_x, pov_y, pov_z, pan_x, pan_y, ClientRectangle.Width, ClientRectangle.Height, pov_d, 0, 0);
             CastGraphChangedEvent();
@@ -698,9 +698,9 @@ namespace T7
         public SurfaceGraphViewer()
         {
             InitializeComponent();
-            this.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.SurfaceGraphMouseWheel);
-
+            MouseWheel += SurfaceGraphMouseWheel;
             sr = new Surface3DRenderer(pov_x, pov_y, pov_z, pan_x, pan_y, ClientRectangle.Width, ClientRectangle.Height, pov_d, 0, 0);
+            BackColor = Color.White;
             sr.ColorSchema = new ColorSchema(0);
             sr.Density = 1; 
             ResizeRedraw = true;

--- a/T7Suite/T7.csproj
+++ b/T7Suite/T7.csproj
@@ -529,7 +529,9 @@
     <None Include="ASM-Mode.xshd">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <Content Include="canlib32.dll" />
+    <Content Include="canlib32.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="DTC_Descriptions.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/T8Suite/SurfaceGraphViewer.cs
+++ b/T8Suite/SurfaceGraphViewer.cs
@@ -686,8 +686,7 @@ namespace T8SuitePro
         private void SurfaceGraphMouseWheel(object sender, System.Windows.Forms.MouseEventArgs e)
         {
             int delta = e.Delta;
-            if (e.Delta > 0xff000000) delta = (int)(0x100000000 - (long)delta); // Warning: Comparison to integral constant is useless; the constant is outside the range of type 'int'
-
+            //if (e.Delta > 0xff000000) delta = (int)(0x100000000 - (long)delta); // Warning: Comparison to integral constant is useless; the constant is outside the range of type 'int'
             pov_d += (delta * 0.0001);
             sr.ReCalculateTransformationsCoeficients(pov_x, pov_y, pov_z, pan_x, pan_y, ClientRectangle.Width, ClientRectangle.Height, pov_d, 0, 0);
             CastGraphChangedEvent();
@@ -697,9 +696,9 @@ namespace T8SuitePro
         public SurfaceGraphViewer()
         {
             InitializeComponent();
-            this.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.SurfaceGraphMouseWheel);
-
+            MouseWheel += SurfaceGraphMouseWheel;
             sr = new Surface3DRenderer(pov_x, pov_y, pov_z, pan_x, pan_y, ClientRectangle.Width, ClientRectangle.Height, pov_d, 0, 0);
+            BackColor = Color.White;
             sr.ColorSchema = new ColorSchema(0);
             sr.Density = 1; 
             ResizeRedraw = true;

--- a/T8Suite/T8SuitePro.csproj
+++ b/T8Suite/T8SuitePro.csproj
@@ -509,7 +509,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <Content Include="canlib32.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <EmbeddedResource Include="Compressormaps\GT17.jpg" />
     <EmbeddedResource Include="Compressormaps\gt2871r-48.jpg" />


### PR DESCRIPTION
Both in T7 and T8 in the constrctor of SurfaceGraphViewer "BackColor" is now initialized to white.
In T7 canlib32.dll was not copied to the build directory.
Refreshed T7 setup project that wasn't building anymore.