### PR TITLE
Temporary fix

### DIFF
--- a/T7Suite/frmMain.cs
+++ b/T7Suite/frmMain.cs
@@ -7674,7 +7674,8 @@ TorqueCal.M_IgnInflTroqMap 8*/
                                 // Should we start a viewer in realtime mode or in offline mode?
                                 if (m_RealtimeConnectedToECU)
                                 {
-                                    ShowRealtimeMapFromECU(sh.SmartVarname);
+                                    // ShowRealtimeMapFromECU(sh.SmartVarname);
+                                    StartTableViewer(ECUMode.Auto);
                                 }
                                 else
                                 {
@@ -7688,7 +7689,8 @@ TorqueCal.M_IgnInflTroqMap 8*/
                                     logger.Debug("Retrieving stuff from SRAM at address: " + sh.Flash_start_address.ToString("X6"));
                                     if (RealtimeCheckAndConnect())
                                     {
-                                        ShowRealtimeMapFromECU(sh.SmartVarname);
+                                        // ShowRealtimeMapFromECU(sh.SmartVarname);
+                                        StartTableViewer(ECUMode.Auto);
                                     }
                                 }
                                 else


### PR DESCRIPTION
This is not an actual fix since it reverts to the old behaviour where the user have to manually update a table viewer (or use the interval refresh-thingy in settings) but at least the viewer shows. (it does however read data from sram once when opening it)

I noticed the problem does not affect "gridViewSymbols_DoubleClick" even tho it's making the same calls. Might be a hint for an actual fix in the future. (Nor does it enter auto-update mode for some strange reason)