### PR TITLE
Various fixes and quality of life

### DIFF
--- a/T8Suite/CompareResults.cs
+++ b/T8Suite/CompareResults.cs
@@ -106,26 +106,12 @@ namespace T8SuitePro
         {
             if (IsHexMode)
             {
-                
                 gridColumn2.DisplayFormat.FormatType = DevExpress.Utils.FormatType.Numeric;
                 gridColumn2.DisplayFormat.FormatString = "X6";
                 gridColumn2.FilterMode = DevExpress.XtraGrid.ColumnFilterMode.DisplayText;
                 gridColumn3.DisplayFormat.FormatType = DevExpress.Utils.FormatType.Numeric;
                 gridColumn3.DisplayFormat.FormatString = "X6";
                 gridColumn3.FilterMode = DevExpress.XtraGrid.ColumnFilterMode.DisplayText;
-                gridColumn4.DisplayFormat.FormatType = DevExpress.Utils.FormatType.Numeric;
-                gridColumn4.DisplayFormat.FormatString = "X6";
-                gridColumn4.FilterMode = DevExpress.XtraGrid.ColumnFilterMode.DisplayText;
-                gridColumn5.DisplayFormat.FormatType = DevExpress.Utils.FormatType.Numeric;
-                gridColumn5.DisplayFormat.FormatString = "X6";
-                gridColumn5.FilterMode = DevExpress.XtraGrid.ColumnFilterMode.DisplayText;
-                gridColumn12.DisplayFormat.FormatType = DevExpress.Utils.FormatType.Numeric;
-                gridColumn12.DisplayFormat.FormatString = "X6";
-                gridColumn12.FilterMode = DevExpress.XtraGrid.ColumnFilterMode.DisplayText;
-                gridColumn13.DisplayFormat.FormatType = DevExpress.Utils.FormatType.Numeric;
-                gridColumn13.DisplayFormat.FormatString = "X6";
-                gridColumn13.FilterMode = DevExpress.XtraGrid.ColumnFilterMode.DisplayText;
-
             }
             else
             {
@@ -135,21 +121,22 @@ namespace T8SuitePro
                 gridColumn3.DisplayFormat.FormatType = DevExpress.Utils.FormatType.Numeric;
                 gridColumn3.DisplayFormat.FormatString = "";
                 gridColumn3.FilterMode = DevExpress.XtraGrid.ColumnFilterMode.Value;
-                gridColumn4.DisplayFormat.FormatType = DevExpress.Utils.FormatType.Numeric;
-                gridColumn4.DisplayFormat.FormatString = "";
-                gridColumn4.FilterMode = DevExpress.XtraGrid.ColumnFilterMode.Value;
-                gridColumn5.DisplayFormat.FormatType = DevExpress.Utils.FormatType.Numeric;
-                gridColumn5.DisplayFormat.FormatString = "";
-                gridColumn5.FilterMode = DevExpress.XtraGrid.ColumnFilterMode.Value;
-                gridColumn12.DisplayFormat.FormatType = DevExpress.Utils.FormatType.Numeric;
-                gridColumn12.DisplayFormat.FormatString = "";
-                gridColumn12.FilterMode = DevExpress.XtraGrid.ColumnFilterMode.Value;
-                gridColumn13.DisplayFormat.FormatType = DevExpress.Utils.FormatType.Numeric;
-                gridColumn13.DisplayFormat.FormatString = "";
-                gridColumn13.FilterMode = DevExpress.XtraGrid.ColumnFilterMode.Value;
             }
-        }
 
+            // Lengths and counts are always easier to read in decimal mode
+            gridColumn4.DisplayFormat.FormatType = DevExpress.Utils.FormatType.Numeric;
+            gridColumn4.DisplayFormat.FormatString = "";
+            gridColumn4.FilterMode = DevExpress.XtraGrid.ColumnFilterMode.Value;
+            gridColumn5.DisplayFormat.FormatType = DevExpress.Utils.FormatType.Numeric;
+            gridColumn5.DisplayFormat.FormatString = "";
+            gridColumn5.FilterMode = DevExpress.XtraGrid.ColumnFilterMode.Value;
+            gridColumn12.DisplayFormat.FormatType = DevExpress.Utils.FormatType.Numeric;
+            gridColumn12.DisplayFormat.FormatString = "";
+            gridColumn12.FilterMode = DevExpress.XtraGrid.ColumnFilterMode.Value;
+            gridColumn13.DisplayFormat.FormatType = DevExpress.Utils.FormatType.Numeric;
+            gridColumn13.DisplayFormat.FormatString = "";
+            gridColumn13.FilterMode = DevExpress.XtraGrid.ColumnFilterMode.Value;
+        }
 
         public CompareResults()
         {

--- a/T8Suite/Form1.cs
+++ b/T8Suite/Form1.cs
@@ -2011,10 +2011,8 @@ namespace T8SuitePro
                     }
 
                     SymbolHelper sh = (SymbolHelper)gridViewSymbols.GetRow((int)selrows.GetValue(0));
-                    if (sh.Flash_start_address == 0 && sh.Start_address == 0)
+                    if (sh == null || (sh.Flash_start_address == 0 && sh.Start_address == 0))
                         return;
-
-                    if (sh == null) return;
 
                     if (sh.BitMask > 0)
                     {
@@ -2242,7 +2240,7 @@ namespace T8SuitePro
                                 }
                                 else
                                 {
-                                    logger.Debug("StartTableViewer: Tried wrong open");
+                                    // logger.Debug("StartTableViewer: Tried wrong open");
                                 }
 
                                 logger.Debug("mapdata len: " + mapdata.Length.ToString());
@@ -2272,16 +2270,22 @@ namespace T8SuitePro
                                 tabdet.ShowTable(columns, isSixteenBitTable(tabdet.Map_name));
 
                                 tabdet.Dock = DockStyle.Fill;
-                                tabdet.onSymbolSave += new IMapViewer.NotifySaveSymbol(tabdet_onSymbolSave);
+
+                                if (address > 0 && address < 0x100000)
+                                {
+                                    tabdet.onSymbolSave += new IMapViewer.NotifySaveSymbol(tabdet_onSymbolSave);
+                                    tabdet.onSymbolRead += new IMapViewer.NotifyReadSymbol(tabdet_onSymbolRead);
+                                }
+
+                                if (sramaddress >= 0x100000)
+                                {
+                                    tabdet.onWriteToSRAM += new IMapViewer.WriteDataToSRAM(tabdet_onWriteToSRAM);
+                                    tabdet.onReadFromSRAM += new IMapViewer.ReadDataFromSRAM(tabdet_onReadFromSRAM);
+                                }
+
                                 tabdet.onClose += new IMapViewer.ViewerClose(tabdet_onClose);
-
-                                tabdet.onWriteToSRAM += new IMapViewer.WriteDataToSRAM(tabdet_onWriteToSRAM);
-                                tabdet.onReadFromSRAM += new IMapViewer.ReadDataFromSRAM(tabdet_onReadFromSRAM);
-
-
                                 tabdet.onSelectionChanged += new IMapViewer.SelectionChanged(tabdet_onSelectionChanged);
                                 tabdet.onSurfaceGraphViewChangedEx += new IMapViewer.SurfaceGraphViewChangedEx(mv_onSurfaceGraphViewChangedEx);
-                                tabdet.onSymbolRead += new IMapViewer.NotifyReadSymbol(tabdet_onSymbolRead);
                                 tabdet.onAxisEditorRequested += new IMapViewer.AxisEditorRequested(tabdet_onAxisEditorRequested);
 
                                 //tabdet.onAxisLock += new MapViewer.NotifyAxisLock(tabdet_onAxisLock);

--- a/T8Suite/Form1.cs
+++ b/T8Suite/Form1.cs
@@ -2838,7 +2838,7 @@ namespace T8SuitePro
 
         private void StartTableViewer(string symbolname)
         {
-            if (GetSymbolAddress(m_symbols, symbolname) > 0)
+            if (GetSymbolAddress(m_symbols, symbolname) > 0 || GetSymbolAddressSRAM(m_symbols, symbolname) >= 0x100000)
             {
                 gridViewSymbols.ActiveFilter.Clear(); // clear filter
                 gridViewSymbols.ApplyFindFilter("");

--- a/T8Suite/Form1.cs
+++ b/T8Suite/Form1.cs
@@ -2245,7 +2245,7 @@ namespace T8SuitePro
                                     logger.Debug("StartTableViewer: Tried wrong open");
                                 }
 
-                                logger.Debug("mapdata len: " + mapdata.Length.ToString("X4"));
+                                logger.Debug("mapdata len: " + mapdata.Length.ToString());
 
                                 tabdet.Map_content = mapdata;
 
@@ -2729,7 +2729,7 @@ namespace T8SuitePro
             LoadMyMaps();
         }
 
-        private void ShowBtnIfSymbolInBin(string symbolname, DevExpress.XtraBars.BarButtonItem btn )
+        private void ShowBtnIfSymbolInBin(string symbolname, DevExpress.XtraBars.BarButtonItem btn)
         {
             SymbolCollection sc = (SymbolCollection)gridControlSymbols.DataSource;
             foreach (SymbolHelper sh in sc)
@@ -3329,7 +3329,6 @@ namespace T8SuitePro
 
                         dockPanel.Width = 700;
 
-
                         SymbolCollection compare_symbols = new SymbolCollection();
 
                         logger.Debug("Opening compare file");
@@ -3358,6 +3357,9 @@ namespace T8SuitePro
                         dt.Columns.Add("Userdescription");
                         dt.Columns.Add("MissingInOriFile", Type.GetType("System.Boolean"));
                         dt.Columns.Add("MissingInCompareFile", Type.GetType("System.Boolean"));
+
+                        compareResults.ShowAddressesInHex = m_appSettings.ShowAddressesInHex;
+                        compareResults.SetFilterMode(m_appSettings.ShowAddressesInHex);
 
                         double diffperc = 0;
                         int diffabs = 0;
@@ -12701,7 +12703,6 @@ TrqMastCal.m_AirTorqMap -> 325 Nm = 1300 mg/c             * */
                         tabdet.Correction_factor = GetMapCorrectionFactor(tabdet.Map_name);
                         tabdet.Correction_offset = GetMapCorrectionOffset(tabdet.Map_name);
                         tabdet.IsUpsideDown = GetMapUpsideDown(tabdet.Map_name);
-
                         tabdet.ShowTable(columns, isSixteenBitTable(tabdet.Map_name));
 
                         tabdet.IsRAMViewer = true;
@@ -12908,7 +12909,6 @@ TrqMastCal.m_AirTorqMap -> 325 Nm = 1300 mg/c             * */
 
         void tabdet_onReadFromSRAM(object sender, IMapViewer.ReadFromSRAMEventArgs e)
         {
-            // MessageBox.Show("On read sram");
             // read data from SRAM through CAN bus and refresh the viewer with it
             bool writepossible = false;
             try
@@ -12930,6 +12930,7 @@ TrqMastCal.m_AirTorqMap -> 325 Nm = 1300 mg/c             * */
                                 {
                                     try
                                     {
+                                        IMapViewer tabdet = (IMapViewer)sender;
                                         byte[] result = ReadMapFromSRAM(shs);
                                         if (result == null)
                                         {
@@ -12950,9 +12951,11 @@ TrqMastCal.m_AirTorqMap -> 325 Nm = 1300 mg/c             * */
                                                         {
                                                             vwr.Map_content = result;
                                                             GetTableMatrixWitdhByName(m_currentfile, m_symbols, e.Mapname, out cols, out rows);
+                                                            if (tabdet.X_axisvalues.Length > 1) cols = tabdet.X_axisvalues.Length;
+                                                            if (tabdet.Y_axisvalues.Length > 1) rows = tabdet.Y_axisvalues.Length;
                                                             vwr.IsRAMViewer = false;
                                                             vwr.ShowTable(cols, isSixteenBitTable(e.Mapname));
-                                                            if ((m_RealtimeConnectedToECU) /*|| m_appSettings.DebugMode*/)
+                                                            if (m_RealtimeConnectedToECU)
                                                             {
                                                                 vwr.OnlineMode = true;
                                                                 vwr.IsRAMViewer = true;
@@ -12975,9 +12978,11 @@ TrqMastCal.m_AirTorqMap -> 325 Nm = 1300 mg/c             * */
                                                                 {
                                                                     vwr2.Map_content = result;
                                                                     GetTableMatrixWitdhByName(m_currentfile, m_symbols, e.Mapname, out cols, out rows);
+                                                                    if (tabdet.X_axisvalues.Length > 1) cols = tabdet.X_axisvalues.Length;
+                                                                    if (tabdet.Y_axisvalues.Length > 1) rows = tabdet.Y_axisvalues.Length;
                                                                     vwr2.IsRAMViewer = false;
                                                                     vwr2.ShowTable(cols, isSixteenBitTable(e.Mapname));
-                                                                    if ((m_RealtimeConnectedToECU) /*|| m_appSettings.DebugMode*/)
+                                                                    if (m_RealtimeConnectedToECU)
                                                                     {
                                                                         vwr2.OnlineMode = true;
                                                                         vwr2.IsRAMViewer = true;
@@ -13002,6 +13007,8 @@ TrqMastCal.m_AirTorqMap -> 325 Nm = 1300 mg/c             * */
                                                                 {
                                                                     vwr3.Map_content = result;
                                                                     GetTableMatrixWitdhByName(m_currentfile, m_symbols, e.Mapname, out cols, out rows);
+                                                                    if (tabdet.X_axisvalues.Length > 1) cols = tabdet.X_axisvalues.Length;
+                                                                    if (tabdet.Y_axisvalues.Length > 1) rows = tabdet.Y_axisvalues.Length;
                                                                     vwr3.IsRAMViewer = false;
                                                                     vwr3.ShowTable(cols, isSixteenBitTable(e.Mapname));
                                                                     if ((m_RealtimeConnectedToECU) /*|| m_appSettings.DebugMode*/)
@@ -13045,8 +13052,6 @@ TrqMastCal.m_AirTorqMap -> 325 Nm = 1300 mg/c             * */
             // Why? Let the read function handle that
             m_prohibitReading = false;
         }
-
-
 
         void tabdet_onWriteToSRAM(object sender, IMapViewer.WriteToSRAMEventArgs e)
         {

--- a/T8Suite/Trionic8File.cs
+++ b/T8Suite/Trionic8File.cs
@@ -1054,7 +1054,6 @@ namespace T8SuitePro
         /// <param name="sOffset">Secondary offset</param>
         static private void TranslateAddressOffsets(SymbolCollection symbols, int PriOffset, int SecOffset)
         {
-            logger.Debug("Offset: " + PriOffset.ToString("X6"));
             try
             {
                 if (symbols != null)

--- a/T8Suite/Trionic8File.cs
+++ b/T8Suite/Trionic8File.cs
@@ -1054,6 +1054,7 @@ namespace T8SuitePro
         /// <param name="sOffset">Secondary offset</param>
         static private void TranslateAddressOffsets(SymbolCollection symbols, int PriOffset, int SecOffset)
         {
+            logger.Debug("Offset: " + PriOffset.ToString("X6"));
             try
             {
                 if (symbols != null)
@@ -1078,9 +1079,9 @@ namespace T8SuitePro
                             // SRAM address
                             sh.Start_address = sh.Internal_address;
 
-                            // NVDM symbols on open binaries are tagged with 0xff.
-                            // The type mask should ideally be checked some more since some combinations are invalid
-                            if (sh.Symbol_type != 0xff && (sh.Symbol_type & 0x22) > 0)
+                            // NVDM symbols are tagged with 0xff.
+                            // Adaption symbols are sometimes tagged as being cal (which is definitely not true) so these must be masked off
+                            if (sh.Symbol_type != 0xff && (sh.Symbol_type & 0x22) == 0x02)
                             {
                                 int actAddress = 0;
 
@@ -1112,7 +1113,7 @@ namespace T8SuitePro
                                 }
 
                                 // Real address must be within range
-                                if ((actAddress + sh.Length) <= 0x100000)
+                                if ((actAddress + sh.Length) <= 0x100000 && actAddress > 0)
                                 {
                                     sh.Flash_start_address = actAddress;
                                 }


### PR DESCRIPTION
1. Do not perform address translation on adaption/obd symbols since they belong to a third data section with different offsets.
2. I don't know if I introduced this bug or if it was already there but sram viewers had a hard time figuring out symbol axis so some where incorrectly displayed when read from sram.
3. Made sure CompareResult dialog actually follows main app settings for hex/decimal and tweaked the code to only apply this change to displayed address. (lengths are virtually always easier to read in decimal) Shout if you think it's a bad idea and I'll exclude the last change.