### PR TITLE
live-tuneable should include sram-only

### DIFF
--- a/T8Suite/Form1.cs
+++ b/T8Suite/Form1.cs
@@ -723,8 +723,17 @@ namespace T8SuitePro
 
         private void SetDefaultFilters()
         {
-            ColumnFilterInfo fltr = new DevExpress.XtraGrid.Columns.ColumnFilterInfo("[Flash_start_address] LIKE '0_____' AND [Length] <> '000000' AND [Flash_start_address] < 1048576", "Only symbols within binary");
-            ColumnFilterInfo lvefltr = new DevExpress.XtraGrid.Columns.ColumnFilterInfo("[Flash_start_address] LIKE '0_____' AND [Length] <> '000000' AND [Start_address] > 1048575", "Only live-tuneable symbols");
+            ColumnFilterInfo fltr, lvefltr;
+            if (m_appSettings.ShowAddressesInHex)
+            {
+                fltr = new DevExpress.XtraGrid.Columns.ColumnFilterInfo("[Flash_start_address] LIKE '0_____' AND [Length] <> '000000' AND [Flash_start_address] < 100000", "Only symbols within binary");
+                lvefltr = new DevExpress.XtraGrid.Columns.ColumnFilterInfo("[Length] <> '000000' AND [Start_address] >= 100000", "Only live-tuneable symbols");
+            }
+            else
+            {
+                fltr = new DevExpress.XtraGrid.Columns.ColumnFilterInfo("[Flash_start_address] LIKE '0_____' AND [Length] <> '000000' AND [Flash_start_address] < 1048576", "Only symbols within binary");
+                lvefltr = new DevExpress.XtraGrid.Columns.ColumnFilterInfo("[Length] <> '000000' AND [Start_address] > 1048575", "Only live-tuneable symbols");
+            }
             gridViewSymbols.ActiveFilter.Clear();
             m_filterstate = gridViewSymbols.ActiveFilterEnabled = true;
 


### PR DESCRIPTION
An override/manual handling would be much better for this since it's unaware of hex vs dec mode.
